### PR TITLE
Fix various duplicate pin names on melonHD symbol

### DIFF
--- a/KiCAD/SMT Module Library/melonHD_module.kicad_sym
+++ b/KiCAD/SMT Module Library/melonHD_module.kicad_sym
@@ -163,7 +163,7 @@
 			(pin input line
 				(at -21.59 1.27 0)
 				(length 2.54)
-				(name "TMDS0-"
+				(name "TMDS0+"
 					(effects
 						(font
 							(size 1.27 1.27)

--- a/KiCAD/SMT Module Library/melonHD_module.kicad_sym
+++ b/KiCAD/SMT Module Library/melonHD_module.kicad_sym
@@ -618,7 +618,7 @@
 			(pin input line
 				(at 11.43 -25.4 180)
 				(length 2.54)
-				(name "CC1"
+				(name "CC2"
 					(effects
 						(font
 							(size 1.27 1.27)


### PR DESCRIPTION
On the schematic symbol for the melonHD, `CC1` appears twice. This fixes the second one to be `CC2`.

EDIT: Also was the case for `TMDS0-`